### PR TITLE
Update chat.py

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -71,7 +71,7 @@ def load_convo():
         data = load_json('chat_logs/%s' % file)
         result.append(data)
     ordered = sorted(result, key=lambda d: d['time'], reverse=False)  # sort them all chronologically
-    return result
+    return ordered
 
 
 def summarize_memories(memories):  # summarize a block of memories into one payload


### PR DESCRIPTION
corrected load_convo to return sorted messages. This error could permit prompting with out-of-order messages.